### PR TITLE
Add AGENTS instructions for remote images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Repository Agent Instructions
+
+This repository hosts slide decks published via GitHub Pages.
+
+## Remote images
+- Do not add external images to the repository. Instead record their URLs in `assets/external_images.yaml`.
+- Each entry in `assets/external_images.yaml` should provide a `name`, `url`, and `description`.
+- Slides and documentation should reference images by these URLs rather than embedding files here.
+
+## Local images
+- Local images that must be versioned belong in `assets/images/` with descriptions in `assets/meta.yaml`.
+

--- a/assets/external_images.yaml
+++ b/assets/external_images.yaml
@@ -1,0 +1,13 @@
+external_images:
+  - name: leaveanest_logo
+    url: https://lne.st/wp-content/uploads/2022/04/LeaveaNest_logo_header.png
+    description: "株式会社リバネスのロゴ"
+  - name: knowledge_logo
+    url: https://k.lne.st/wp-content/uploads/sites/76/2022/08/lnest_knowledge-.png
+    description: "株式会社リバネスナレッジのロゴ"
+  - name: dreamforce_2019
+    url: https://lne.st/wp-content/uploads/2025/05/7e97b4dac4bfd3718fa55f612fcbce1c.png
+    description: "2019年Dreamforce登壇時の画像"
+  - name: yoshida_profile
+    url: https://lne.st/wp-content/uploads/2025/05/78626087_10221322607716697_5436811581734256640_n-9.jpg
+    description: "吉田丈治のプロフィール画像"


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with instructions on storing remote image URLs in `assets/external_images.yaml`
- create `external_images.yaml` listing image URLs

## Testing
- `git status --short`