### PR TITLE
Fix Node setup caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install dependencies
         working-directory: slides/2025-05-22-salesforce-innovation-day-osaka-dx
@@ -42,7 +41,7 @@ jobs:
 
       - uses: actions/configure-pages@v4
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: public
       - uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Summary
- configure workflow to use upload-pages-artifact@v3
- drop npm cache setting so the workflow no longer errors when the repo has no lockfile

## Testing
- `git log -1 --stat`