### PR TITLE
Fix Slidev build on Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: '18'
 
       - name: Install dependencies
         working-directory: slides/2025-05-22-salesforce-innovation-day-osaka-dx
@@ -31,6 +30,8 @@ jobs:
 
       - name: Build slide deck
         working-directory: slides/2025-05-22-salesforce-innovation-day-osaka-dx
+        env:
+          CI: 'true'
         run: npx slidev build --base /${{ github.event.repository.name }}/slides/2025-05-22-salesforce-innovation-day-osaka-dx/
 
       - name: Prepare pages directory
@@ -42,7 +43,7 @@ jobs:
 
       - uses: actions/configure-pages@v4
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: public
       - uses: actions/deploy-pages@v1

--- a/slides/2025-05-22-salesforce-innovation-day-osaka-dx/package.json
+++ b/slides/2025-05-22-salesforce-innovation-day-osaka-dx/package.json
@@ -7,6 +7,7 @@
     "export": "slidev export"
   },
   "devDependencies": {
-    "@slidev/cli": "^0.48.4"
+    "@slidev/cli": "^0.48.4",
+    "@slidev/theme-default": "^0.48.4"
   }
 }


### PR DESCRIPTION
## Summary
- set Node.js version to 18 and remove npm cache
- ensure non-interactive build using `CI=true`
- install the default Slidev theme

## Testing
- `git log -1 --stat`
